### PR TITLE
modified KernelTestCase to phpunit basic TestCase

### DIFF
--- a/tests/Service/PasswordManagerTest.php
+++ b/tests/Service/PasswordManagerTest.php
@@ -4,9 +4,9 @@ namespace App\Tests\Service;
 
 use App\Service\PasswordManager;
 use Generator;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use PHPUnit\Framework\TestCase;
 
-class PasswordManagerTest extends KernelTestCase
+class PasswordManagerTest extends TestCase
 {
     public function testClassExists(): void
     {


### PR DESCRIPTION
modified KernelTestCase to phpunit basic TestCase because we actually don't need to boot the Symfony Kernel